### PR TITLE
Fix typo in macro

### DIFF
--- a/fontconfig.spec
+++ b/fontconfig.spec
@@ -109,7 +109,7 @@ cat %{name}-conf.lang >> %{name}.lang
 make check
 
 %post
-{?ldconfig: %ldconfig}
+%{?ldconfig: %ldconfig}
 
 umask 0022
 


### PR DESCRIPTION
This typo cause warning message during install package.